### PR TITLE
bugfix: deal with image dimensionality different than labels dimensionality

### DIFF
--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -11,7 +11,11 @@ from skimage.measure import regionprops_table
 
 @napari_hook_implementation
 def napari_experimental_provide_function():
-    return [regionprops]
+    return [regionprops, duplicate_current_frame]
+
+def duplicate_current_frame(image: ImageData, napari_viewer : Viewer, axis : int = 0) -> ImageData:
+    current_dim_value = napari_viewer.dims.current_step[axis]
+    return np.take(image, current_dim_value, axis)
 
 def regionprops(image: ImageData, labels: LabelsData, napari_viewer : Viewer, size : bool = True, intensity : bool = True, perimeter : bool = False, shape : bool = False, position : bool = False, moments : bool = False):
     """

--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -20,6 +20,18 @@ def regionprops(image: ImageData, labels: LabelsData, napari_viewer : Viewer, si
 
     if image is not None and labels is not None:
 
+        # deal with dimensionality of data
+        if len(image.shape) > len(labels.shape):
+            dim = 0
+            subset = ""
+            while len(image.shape) > len(labels.shape):
+                current_dim_value = napari_viewer.dims.current_step[dim]
+                dim = dim + 1
+                image = image[current_dim_value]
+                subset = subset + ", " + str(current_dim_value)
+            warnings.warn("Not the full image was analysed, just the subset [" + subset[2:] + "] according to selected timepoint / slice.")
+
+
         properties = ['label']
         extra_properties = []
 


### PR DESCRIPTION
This closes #1 by automatically extracting the currently selected frame before analysing an image/label. The user is warned like this:
![image](https://user-images.githubusercontent.com/12660498/126695622-7eee0da2-a16e-4f66-9104-4730abe62749.png)

I'm also adding a function for doing this manually

