### PR TITLE
fix wrong indexing in napari status bar

### DIFF
--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -76,6 +76,13 @@ class TableWidget(QWidget):
         """
         if table is None:
             table = {}
+
+        # Workaround to fix wrong row display in napari status bar
+        # https://github.com/napari/napari/issues/4250
+        # https://github.com/napari/napari/issues/2596
+        if "label" in table.keys() and "index" not in table.keys():
+            table["index"] = table["label"]
+
         self._table = table
 
         self._layer.properties = table


### PR DESCRIPTION
This is a workaround ensuring that the status bar show the right entry of the properties/features table. See also:
* https://github.com/napari/napari/issues/4250
* https://github.com/napari/napari/issues/2596