### PR TITLE
Lazy imports of `TableWidget` and `register_function`

### DIFF
--- a/napari_skimage_regionprops/__init__.py
+++ b/napari_skimage_regionprops/__init__.py
@@ -1,8 +1,15 @@
-from ._table import add_table, get_table, TableWidget
 from ._regionprops import regionprops, regionprops_table, regionprops_table_all_frames
 from ._parametric_images import visualize_measurement_on_labels, relabel
 from napari_plugin_engine import napari_hook_implementation
 from ._load_csv import load_csv
+
+try:
+    from ._table import add_table, get_table, TableWidget
+except ModuleNotFoundError as e:
+    import logging
+    logging.warning(e)
+    class TableWidget:
+        pass
 
 try:
     from ._version import version as __version__

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -1,5 +1,5 @@
 import numpy as np
-from napari_tools_menu import register_function
+from ._register_function import register_function
 
 @register_function(menu="Measurement > Load from CSV (nsr)")
 def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer:"napari.layers.Labels", viewer:"napari.Viewer"=None):

--- a/napari_skimage_regionprops/_parametric_images.py
+++ b/napari_skimage_regionprops/_parametric_images.py
@@ -1,6 +1,8 @@
 import numpy as np
-from napari_tools_menu import register_function
+from ._register_function import register_function
 import numpy
+
+
 
 @register_function(menu="Visualization > Measurements on labels (nsr)")
 def visualize_measurement_on_labels(labels_layer:"napari.layers.Labels", column:str = "label", viewer:"napari.Viewer" = None) -> "napari.types.ImageData":

--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -2,9 +2,9 @@ import warnings
 
 import numpy as np
 import pandas
-from napari_tools_menu import register_function
-import math
 from ._all_frames import analyze_all_frames
+from ._register_function import register_function
+import math
 
 def regionprops(image_layer : "napari.layers.Layer", labels_layer: "napari.layers.Labels", size : bool = True, intensity : bool = True, perimeter : bool = False, shape : bool = False, position : bool = False, moments : bool = False, napari_viewer : "napari.Viewer" = None):
     warnings.warn("napari_skimage_regionprops.regionprops is deprecated. Use regionprops_table instead.")

--- a/napari_skimage_regionprops/_register_function.py
+++ b/napari_skimage_regionprops/_register_function.py
@@ -1,5 +1,5 @@
 """
-This module replaced the napari_tools_menu.register_function decorator with a
+This module replaces the napari_tools_menu.register_function decorator with a
 custom one, when the import fails. The new decorator simply discards the menu
 argument and then executes the decorated function as is.
 """

--- a/napari_skimage_regionprops/_register_function.py
+++ b/napari_skimage_regionprops/_register_function.py
@@ -1,0 +1,19 @@
+"""
+This module mimicks yhe napari_tools_menu.register_function decorator, but it
+simply discards the menu argument and then executes the decorated function.It
+is meant as a fall-back option for when napari_tools_menu cannot be imported.
+"""
+
+
+try:
+    from napari_tools_menu import register_function
+except ModuleNotFoundError as e:
+    from typing import Callable
+    from toolz import curry
+    import logging
+    logging.warning(e)
+    logging.warning("Replace napari_tools_menu.register_function with custom decorator")
+    #from ._custom_register_function_decorator import register_function
+    @curry
+    def register_function(func: Callable, menu:str, *args, **kwargs) -> Callable:
+        return func

--- a/napari_skimage_regionprops/_register_function.py
+++ b/napari_skimage_regionprops/_register_function.py
@@ -1,9 +1,8 @@
 """
-This module mimicks yhe napari_tools_menu.register_function decorator, but it
-simply discards the menu argument and then executes the decorated function.It
-is meant as a fall-back option for when napari_tools_menu cannot be imported.
+This module replaced the napari_tools_menu.register_function decorator with a
+custom one, when the import fails. The new decorator simply discards the menu
+argument and then executes the decorated function as is.
 """
-
 
 try:
     from napari_tools_menu import register_function

--- a/napari_skimage_regionprops/_register_function.py
+++ b/napari_skimage_regionprops/_register_function.py
@@ -10,9 +10,10 @@ except ModuleNotFoundError as e:
     from typing import Callable
     from toolz import curry
     import logging
+
     logging.warning(e)
     logging.warning("Replace napari_tools_menu.register_function with custom decorator")
-    #from ._custom_register_function_decorator import register_function
+
     @curry
     def register_function(func: Callable, menu:str, *args, **kwargs) -> Callable:
         return func

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -1,7 +1,7 @@
 from pandas import DataFrame
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QTableWidget, QHBoxLayout, QTableWidgetItem, QWidget, QGridLayout, QPushButton, QFileDialog
-from napari_tools_menu import register_function
+from ._register_function import register_function
 
 import pandas as pd
 from typing import Union

--- a/napari_skimage_regionprops/_utilities.py
+++ b/napari_skimage_regionprops/_utilities.py
@@ -1,6 +1,7 @@
 import numpy as np
 from napari_plugin_engine import napari_hook_implementation
-from napari_tools_menu import register_function
+from ._register_function import register_function
+
 from typing_extensions import Annotated
 from napari.layers import Image, Labels, Layer
 LayerInput = Annotated[Layer, {"label": "Image"}]


### PR DESCRIPTION
I am basing this PR on the `avoid-import-napari` branch, just to see whether it is an interesting way forward. But this means that tests are not passing (as they were not passing in https://github.com/haesleinhuepf/napari-skimage-regionprops/pull/28). I can start over from `master` and get passing tests, if you prefer.

Content-wise, I didn't find a way to delay imports (AKA moving them within functions) for the cases I looked at, because of `TableWidget` (imported from `_table.py` into `__init__.py`) and of the `register_function` decorator. My best solution was to replace them with mocks, when the actual import fails (either because of QT-related imports, or because of `napari_tools_menu`). Let me know if it looks like something you are interested in, and in that case we can look at more details (e.g. getting the tests to pass).