### PR TITLE
Avoid 'convex_area' measurements when 2D labels in 3D images

### DIFF
--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -51,8 +51,13 @@ def regionprops_table(image : napari.types.ImageData, labels: napari.types.Label
     extra_properties = []
 
     if size:
-        properties = properties + ['area', 'bbox_area', 'convex_area', 'equivalent_diameter']
-
+        properties = properties + ['area', 'bbox_area', 'equivalent_diameter']
+        # Workaround to avoid existing scikit-image bug
+        # See https://github.com/scikit-image/scikit-image/issues/6432
+        if (len(labels.shape) == 3) and (_check_2D_labels_in_3D_images(labels)):
+            warnings.warn("2D labels are present in 3D label image, 'convex_area' not calculated")
+        else:
+            properties = properties + ['convex_area']
     if intensity:
         properties = properties + ['max_intensity', 'mean_intensity', 'min_intensity']
 
@@ -69,7 +74,13 @@ def regionprops_table(image : napari.types.ImageData, labels: napari.types.Label
             warnings.warn("Perimeter measurements are not supported in 3D")
 
     if shape:
-        properties = properties + ['solidity', 'extent', 'feret_diameter_max', 'local_centroid']
+        properties = properties + ['solidity', 'extent', 'local_centroid']
+        # Workaround to avoid existing scikit-image bug
+        # See https://github.com/scikit-image/scikit-image/issues/6432
+        if (len(labels.shape) == 3) and (_check_2D_labels_in_3D_images(labels)):
+            warnings.warn("2D labels are present in 3D label image, 'feret_diameter_max' not calculated")
+        else:
+            properties = properties + ['feret_diameter_max']
         if len(labels.shape) == 2:
             properties = properties + ['major_axis_length', 'minor_axis_length', 'orientation', 'eccentricity']
             # we need these two to compute some shape descriptors
@@ -185,7 +196,18 @@ def ellipsoid_axis_lengths(table):
 regionprops_table_all_frames = analyze_all_frames(regionprops_table)
 register_function(regionprops_table_all_frames, menu="Measurement tables > Regionprops of all frames (nsr)")
 
+def _check_2D_labels_in_3D_images(label_image):
+    '''
+    Checks if there are 2D labels in a 3D label image
+    '''
+    from skimage.measure import regionprops as sk_regionprops
 
+    measurements = sk_regionprops(label_image)
+    for props in measurements:
+        label_shape = np.array(props.bbox[3:]) - np.array(props.bbox[:3])
+        if np.any(label_shape == 1):
+            return True
+    return False
 
 try:
     # morphometrics API

--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -74,13 +74,13 @@ def regionprops_table(image : napari.types.ImageData, labels: napari.types.Label
             warnings.warn("Perimeter measurements are not supported in 3D")
 
     if shape:
-        properties = properties + ['solidity', 'extent', 'local_centroid']
+        properties = properties + ['extent', 'local_centroid']
         # Workaround to avoid existing scikit-image bug
         # See https://github.com/scikit-image/scikit-image/issues/6432
         if (len(labels.shape) == 3) and (_check_2D_labels_in_3D_images(labels)):
-            warnings.warn("2D labels are present in 3D label image, 'feret_diameter_max' not calculated")
+            warnings.warn("2D labels are present in 3D label image, 'feret_diameter_max' and 'solidity' not calculated")
         else:
-            properties = properties + ['feret_diameter_max']
+            properties = properties + ['solidity', 'feret_diameter_max']
         if len(labels.shape) == 2:
             properties = properties + ['major_axis_length', 'minor_axis_length', 'orientation', 'eccentricity']
             # we need these two to compute some shape descriptors
@@ -108,7 +108,7 @@ def regionprops_table(image : napari.types.ImageData, labels: napari.types.Label
     # weighted_moments_central
     # weighted_moments_hu
     # weighted_moments_normalized
-
+    print('PROPERTIES = ', properties)
     # quantitative analysis using scikit-image's regionprops
     from skimage.measure import regionprops_table as sk_regionprops_table
     table = sk_regionprops_table(np.asarray(labels).astype(int), intensity_image=np.asarray(image),

--- a/napari_skimage_regionprops/_tests/test_function.py
+++ b/napari_skimage_regionprops/_tests/test_function.py
@@ -397,3 +397,21 @@ def test_measure_points():
     points = np.random.random((100, 2)) * 99
 
     nsr.measure_points(points, image)
+
+def test_2d_labels_in_3d_image():
+    import numpy as np
+    labels = np.zeros((6,6,6), dtype=np.uint8)
+    labels[1:4, 1:4, 1:4] = 1 # 3D label
+    labels[4, 1:4, 1:4] = 2 # 2D label
+
+    from napari_skimage_regionprops import regionprops_table
+    table = regionprops_table(labels, labels, size=True, intensity=True, perimeter=True, shape=True, position=True,
+                moments=True)
+
+    # check one measurement
+    assert np.array_equal(table['area'], [27, 9])
+
+    # check that measurements that depend on convex_area are absent in this case
+    assert "convex_area" not in table.keys()
+    assert "feret_max_diameter" not in table.keys()
+    assert "solidity" not in table.keys()


### PR DESCRIPTION
Hi Robert @haesleinhuepf ,

As we briefly discussed, I am adding a small temporary workaround to avoid [scikit-image regionprops bug](https://github.com/scikit-image/scikit-image/issues/6432) when calculating measurements related to 'convex_area' in 3D images when there is a 2D label present.

Basically, it does not compute measurements that rely on that. I am working to get it fixed there, and then these changes can be dropped here, but for now it will avoid error messages for users in napari.

This PR may be of interest to #27  , not a final solution though.

CCing @marabuuu :)

Best,
Marcelo 