### PR TITLE
Catch arbitrary import exceptions

### DIFF
--- a/napari_skimage_regionprops/_all_frames.py
+++ b/napari_skimage_regionprops/_all_frames.py
@@ -8,7 +8,7 @@ from ._utilities import isimage
 
 try:
     import napari
-except ModuleNotFoundError as e:
+except Exception as e:
     import warnings
     warnings.warn(str(e))
 

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -3,7 +3,7 @@ from napari_tools_menu import register_function
 
 try:
     import napari
-except ModuleNotFoundError as e:
+except Exception as e:
     import warnings
     warnings.warn(str(e))
 

--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas
 try:
     import napari
-except ModuleNotFoundError as e:
+except Exception as e:
     warnings.warn(str(e))
 
 from napari_tools_menu import register_function

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -2,7 +2,7 @@ try:
     import napari
     from qtpy.QtCore import QTimer
     from qtpy.QtWidgets import QTableWidget, QHBoxLayout, QTableWidgetItem, QWidget, QGridLayout, QPushButton, QFileDialog
-except ModuleNotFoundError as e:
+except Exception as e:
     import warnings
     warnings.warn(str(e))
     class QWidget:

--- a/napari_skimage_regionprops/_utilities.py
+++ b/napari_skimage_regionprops/_utilities.py
@@ -6,7 +6,7 @@ try:
     from napari.layers import Image, Labels, Layer
     from typing_extensions import Annotated
     LayerInput = Annotated[Layer, {"label": "Image"}]
-except ModuleNotFoundError as e:
+except Exception as e:
     import warnings
     warnings.warn(str(e))
     LayerInput = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy
 scikit-image
 napari
 pandas
-napari-tools-menu>=0.1.18
+napari-tools-menu>=0.1.19
 napari-workflows
 imageio!=2.22.1


### PR DESCRIPTION
This PR matches the PR https://github.com/haesleinhuepf/napari-tools-menu/pull/12 in napari-tools-menu, and it makes importing `napari-skimage-regionprops` doable even in the absence of QT bindings.

The actual change consists in catching **any** exception upon import of `napari` of `qtpy`, rather than just `ModuleNotFoundError` ones. This is necessary especially because for qtpy>=2.3.0 the relevant exception is `qtpy.QtBindingsNotFoundError` (note that this was also addressed in napari, see https://github.com/napari/napari/pull/5388).

On top of that, i raised the minimal napari-tools-menu to 0.1.19, so that https://github.com/haesleinhuepf/napari-tools-menu/pull/12 is included.