### PR TITLE
rename variables in UI and start as regular regionprops

### DIFF
--- a/napari_skimage_regionprops/_multichannel.py
+++ b/napari_skimage_regionprops/_multichannel.py
@@ -32,7 +32,7 @@ def make_element_wise_dict(list_of_keys, list_of_values):
 def _connect_events(widget):
     def toggle_intensity_widgets(event):
         widget.intensity_image_reference.visible = event
-        # If things_inside_things is True when anebling intensity, then enable
+        # If things_inside_things is True when enabling intensity, then enable
         # intensity image inputs
         if (event == True) & (widget.things_inside_things.value == True):
             widget.intensity_images_to_measure.visible = True
@@ -73,9 +73,9 @@ def _connect_events(widget):
     # Intial visibility states
     widget.intensity_image_reference.visible = False
     widget.intensity_images_to_measure.visible = False
-    widget.label_images_to_measure.visible = True
-    widget.configure_summary_statistics.visible = True
-    widget.intersection_over_target_area.visible = True
+    widget.label_images_to_measure.visible = False
+    widget.configure_summary_statistics.visible = False
+    widget.intersection_over_target_area.visible = False
     widget.counts.visible = False
     widget.average.visible = False
     widget.std.visible = False
@@ -94,10 +94,13 @@ widgets_layout_settings = {
         'label': 'Intensity Image Reference'
     },
     'label_images_to_measure': {
-        'label': 'Label Image(s) to Measure'
+        'label': 'Label Image(s) from other Channel(s)'
     },
     'intensity_images_to_measure': {
-        'label': 'Intensity Image(s) to Measure'
+        'label': 'Intensity Image(s) from other Channel(s)'
+    },
+    'things_inside_things': {
+        'label': 'relate to other channel(s)'
     },
     'intersection_over_target_area': {
         'widget_type': 'FloatSlider',
@@ -123,7 +126,7 @@ widgets_layout_settings = {
 
 
 @register_dock_widget(
-    menu="Measurement tables > Measure things inside things (scikit-image, nsr)")
+    menu="Measurement tables > Objects Features/Properties (scikit-image, nsr)")
 # Need magic factory to make hidding and showing functionality available
 @magic_factory(widget_init=_connect_events,
                layout='vertical',
@@ -137,6 +140,8 @@ widgets_layout_settings = {
                    'intensity_images_to_measure'],
                intersection_over_target_area=widgets_layout_settings[
                    'intersection_over_target_area'],
+               things_inside_things=widgets_layout_settings[
+                   'things_inside_things'],
                std=widgets_layout_settings['std'],
                percentile_25=widgets_layout_settings['percentile_25'],
                percentile_75=widgets_layout_settings['percentile_75'])
@@ -328,8 +333,11 @@ def regionprops_measure_things_inside_things(
         else:
             # Check if user provided 'label_images_to_measure'
             if len(label_images_to_measure) == 0:
-                notifications.show_warning(('Error! With \'things inside things\' enabled,'
-                ' at least one \'Label Images(s) to Measure\' is necessary!'))
+                notifications.show_warning(('Error! Add a labels layer to '
+                                            '\'Label Image(s) from other '
+                                            'Channel(s)\' when \'relate '
+                                            'to other channel(s)\' is enabled!')
+                                            )
                 return
             
             # Without intensity measurements
@@ -349,9 +357,12 @@ def regionprops_measure_things_inside_things(
             else:
                 # Check if user provided 'intensity_images_to_measure'
                 if len(intensity_images_to_measure) == 0:
-                    notifications.show_warning(('Error! With \'things inside things\' and \'intensity\''
-                    ' enabled, at least one \'Intensity Images(s) to Measure\' is'
-                     'necessary!'))
+                    notifications.show_warning(('Error! Add an image layer to '
+                                            '\'Intensity Image(s) from other '
+                                            'Channel(s)\' when both \'relate '
+                                            'to other channel(s)\' and \'intensity\''
+                                             ' are enabled!')
+                                            )
                     return
                 table = measure_labels_in_labels_with_intensity(
                 label_image_reference=label_image_reference,

--- a/napari_skimage_regionprops/_tests/test_things_inside_things.py
+++ b/napari_skimage_regionprops/_tests/test_things_inside_things.py
@@ -22,8 +22,8 @@ def test_napari_regionprops_map_2channels_2D(make_napari_viewer):
                               [0, 2, 2, 0],
                               [2, 2, 2, 1]])
 
-    viewer.add_labels(ref_labels)
-    viewer.add_labels(target_labels)
+    viewer.add_labels(ref_labels, name='ref_labels')
+    viewer.add_labels(target_labels, name='target_labels')
 
     widget = regionprops_measure_things_inside_things()
     regionprops_measure_things_inside_things_function = widget._function
@@ -87,9 +87,9 @@ def test_napari_regionprops_map_3channels_2D(make_napari_viewer):
                                 [1, 0, 0, 0],
                                 [0, 0, 0, 0]])
 
-    viewer.add_labels(ref_labels)
-    viewer.add_labels(target_labels)
-    viewer.add_labels(target_labels_B)
+    viewer.add_labels(ref_labels, name='ref_labels')
+    viewer.add_labels(target_labels, name='target_labels')
+    viewer.add_labels(target_labels_B, name='target_labels_B')
 
     widget = regionprops_measure_things_inside_things()
     regionprops_measure_things_inside_things_function = widget._function
@@ -167,8 +167,8 @@ def test_napari_regionprops_map_2channels_3D(make_napari_viewer):
         target_labels_2D]
     )
 
-    viewer.add_labels(ref_labels_3D)
-    viewer.add_labels(target_labels_3D)
+    viewer.add_labels(ref_labels_3D, name='ref_labels_3D')
+    viewer.add_labels(target_labels_3D, name='target_labels_3D')
 
     widget = regionprops_measure_things_inside_things()
     regionprops_measure_things_inside_things_function = widget._function
@@ -201,6 +201,7 @@ def test_napari_regionprops_map_2channels_3D(make_napari_viewer):
     
     assert table.shape == (2, 1549)
     # Check counts
+    print('COLUMNS = ', table.columns)
     assert np.array_equal(table['counts_target_labels_3D'].values, np.array([1., 1.]))
     # Check local_centroid-2 average
     assert np.allclose(table['local_centroid-2_target_labels_3D average'].values, np.array([0.333333, 1.]))

--- a/napari_skimage_regionprops/_tests/test_things_inside_things.py
+++ b/napari_skimage_regionprops/_tests/test_things_inside_things.py
@@ -201,7 +201,6 @@ def test_napari_regionprops_map_2channels_3D(make_napari_viewer):
     
     assert table.shape == (2, 1549)
     # Check counts
-    print('COLUMNS = ', table.columns)
     assert np.array_equal(table['counts_target_labels_3D'].values, np.array([1., 1.]))
     # Check local_centroid-2 average
     assert np.allclose(table['local_centroid-2_target_labels_3D average'].values, np.array([0.333333, 1.]))


### PR DESCRIPTION
- change initial state of widgets to start as regular regionprops
- rename Menu entry
- rename 'things_inside_things' label to 'relate to other channel(s)'
- update notifications accordingly
- add layer names to test file
  - tests were failing locally because layer names were 'Image', 'Image [1]' etc instead of using variable names 
  - this was making `assert` statements fail because table column names rely on layer names
  - explicitly specifying layer names avoids this