### PR TITLE
Limit number of visible rows to work with big datasets

### DIFF
--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -33,13 +33,12 @@ def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: napari.layers
         label_column = pd.DataFrame(
             {"label": np.array(range(1, (len(reg_props) + 1)))}
         )
-        edited_reg_props = pd.concat([label_column, reg_props], axis=1)
+        reg_props = pd.concat([label_column, reg_props], axis=1)
 
     if hasattr(labels_layer, "properties"):
         labels_layer.properties = reg_props
     if hasattr(labels_layer, "features"):
         labels_layer.features = reg_props
-
     labels_layer.metadata["limit_number_rows"] = limit_number_visible_rows
 
     if viewer is not None:

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -7,14 +7,13 @@ except Exception as e:
     import warnings
     warnings.warn(str(e))
 
-
 @register_function(menu="Measurement > Load from CSV (nsr)")
 def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layers.Labels", viewer: "napari.Viewer" = None):
     """Save contents of a CSV file into a given layer's properties"""
     import pandas as pd
 
     # preload to get find datatypes:
-    preload_reg_probs = pd.read_csv("results.csv", nrows=2)
+    preload_reg_probs = pd.read_csv(csv_filename, nrows=2)
     dtypes={}
     for c_i, c in enumerate(preload_reg_probs.columns):
         if preload_reg_probs.dtypes[c_i] == np.float64:

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -22,23 +22,23 @@ def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: napari.layers
             dtypes[c] = preload_reg_probs.dtypes[c_i]
 
 
-    # load region properties from csv file
+    #load region properties from csv file
     reg_props = pd.read_csv(csv_filename, dtype=dtypes)
     try:
-        edited_reg_props = reg_props.drop(["Unnamed: 0"], axis=1)
+        reg_props = reg_props.drop(["Unnamed: 0"], axis=1)
     except KeyError:
-        edited_reg_props = reg_props
+        reg_props = reg_props
 
-    if "label" not in edited_reg_props.keys().tolist():
+    if "label" not in reg_props.keys().tolist():
         label_column = pd.DataFrame(
-            {"label": np.array(range(1, (len(edited_reg_props) + 1)))}
+            {"label": np.array(range(1, (len(reg_props) + 1)))}
         )
-        edited_reg_props = pd.concat([label_column, edited_reg_props], axis=1)
+        edited_reg_props = pd.concat([label_column, reg_props], axis=1)
 
     if hasattr(labels_layer, "properties"):
-        labels_layer.properties = edited_reg_props
+        labels_layer.properties = reg_props
     if hasattr(labels_layer, "features"):
-        labels_layer.features = edited_reg_props
+        labels_layer.features = reg_props
 
     labels_layer.metadata["limit_number_rows"] = limit_number_visible_rows
 

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -8,7 +8,7 @@ except Exception as e:
     warnings.warn(str(e))
 
 @register_function(menu="Measurement > Load from CSV (nsr)")
-def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: napari.layers.Labels, limit_number_visible_rows: int =None, viewer: "napari.Viewer" = None):
+def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layers.Labels", limit_number_visible_rows: int =None, viewer: "napari.Viewer" = None):
     """Save contents of a CSV file into a given layer's properties"""
     import pandas as pd
 

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -8,7 +8,7 @@ except Exception as e:
     warnings.warn(str(e))
 
 @register_function(menu="Measurement > Load from CSV (nsr)")
-def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layers.Labels", viewer: "napari.Viewer" = None):
+def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: napari.layers.Labels, limit_number_visible_rows: bool, viewer: "napari.Viewer" = None):
     """Save contents of a CSV file into a given layer's properties"""
     import pandas as pd
 
@@ -39,6 +39,8 @@ def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layer
         labels_layer.properties = edited_reg_props
     if hasattr(labels_layer, "features"):
         labels_layer.features = edited_reg_props
+
+    labels_layer.metadata["limit_number_rows"] = limit_number_visible_rows
 
     if viewer is not None:
         from ._table import add_table

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -8,7 +8,7 @@ except Exception as e:
     warnings.warn(str(e))
 
 @register_function(menu="Measurement > Load from CSV (nsr)")
-def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layers.Labels", limit_number_visible_rows: int =None, viewer: "napari.Viewer" = None):
+def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layers.Labels", show_table: bool = True, viewer: "napari.Viewer" = None):
     """Save contents of a CSV file into a given layer's properties"""
     import pandas as pd
 
@@ -39,7 +39,8 @@ def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layer
         labels_layer.properties = reg_props
     if hasattr(labels_layer, "features"):
         labels_layer.features = reg_props
-    labels_layer.metadata["limit_number_rows"] = limit_number_visible_rows
+    if show_table is False:
+        labels_layer.metadata["limit_number_rows"] = 0
 
     if viewer is not None:
         from ._table import add_table

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -8,7 +8,7 @@ except Exception as e:
     warnings.warn(str(e))
 
 @register_function(menu="Measurement > Load from CSV (nsr)")
-def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: napari.layers.Labels, limit_number_visible_rows: bool, viewer: "napari.Viewer" = None):
+def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: napari.layers.Labels, limit_number_visible_rows: int =None, viewer: "napari.Viewer" = None):
     """Save contents of a CSV file into a given layer's properties"""
     import pandas as pd
 

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -41,6 +41,8 @@ def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layer
         labels_layer.features = reg_props
     if show_table is False:
         labels_layer.metadata["limit_number_rows"] = 0
+    else:
+        labels_layer.metadata["limit_number_rows"] = 500
 
     if viewer is not None:
         from ._table import add_table

--- a/napari_skimage_regionprops/_load_csv.py
+++ b/napari_skimage_regionprops/_load_csv.py
@@ -12,8 +12,19 @@ except Exception as e:
 def load_csv(csv_filename:"magicgui.types.PathLike", labels_layer: "napari.layers.Labels", viewer: "napari.Viewer" = None):
     """Save contents of a CSV file into a given layer's properties"""
     import pandas as pd
+
+    # preload to get find datatypes:
+    preload_reg_probs = pd.read_csv("results.csv", nrows=2)
+    dtypes={}
+    for c_i, c in enumerate(preload_reg_probs.columns):
+        if preload_reg_probs.dtypes[c_i] == np.float64:
+            dtypes[c] = np.single
+        else:
+            dtypes[c] = preload_reg_probs.dtypes[c_i]
+
+
     # load region properties from csv file
-    reg_props = pd.read_csv(csv_filename)
+    reg_props = pd.read_csv(csv_filename, dtype=dtypes)
     try:
         edited_reg_props = reg_props.drop(["Unnamed: 0"], axis=1)
     except KeyError:

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -156,7 +156,6 @@ class TableWidget(QWidget):
         """
         Overwrites the content of the table with the content of a given dictionary.
         """
-        print("Set content???")
         if table is None:
             table = {}
 
@@ -207,19 +206,18 @@ class TableWidget(QWidget):
         except StopIteration:
             pass
 
+        for i, column in enumerate(table.keys()):
+            self._view.setHorizontalHeaderItem(i, QTableWidgetItem(column))
+            for j, value in enumerate(table.get(column)):
+                if j>max_rows:
+                    break
+                self._view.setItem(j, i, QTableWidgetItem(str(value)))
+
         if max_rows == 0:
             self._view.setRowCount(1)
-            for i, column in enumerate(table.keys()):
-                self._view.setHorizontalHeaderItem(i, QTableWidgetItem(column))
             self._view.setItem(0, 0, QTableWidgetItem(str("Data not shown")))
             self._view.setSpan(0, 0, 1, len(table.keys())+1)
-        else:
-            for i, column in enumerate(table.keys()):
-                self._view.setHorizontalHeaderItem(i, QTableWidgetItem(column))
-                for j, value in enumerate(table.get(column)):
-                    if j>max_rows:
-                        break
-                    self._view.setItem(j, i, QTableWidgetItem(str(value)))
+
 
     def get_content(self) -> dict:
         """
@@ -270,12 +268,10 @@ def add_table(labels_layer: "napari.layers.Layer", viewer: "napari.Viewer", tabi
     """
     dock_widget = get_table(labels_layer, viewer)
     if dock_widget is None:
-        print("HERE")
         dock_widget = TableWidget(labels_layer, viewer)
         # add widget to napari
         viewer.window.add_dock_widget(dock_widget, area='right', name="Properties of " + labels_layer.name, tabify = tabify)
     else:
-        print("HERE2")
         dock_widget.set_content(labels_layer.properties)
         if not dock_widget.parent().isVisible():
             dock_widget.parent().setVisible(True)

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -30,7 +30,6 @@ class TableWidget(QWidget):
         self._view = QTableWidget()
         self._view.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.limit_visible_rows = None
-        self.data_not_shown_label = None
         if "limit_number_rows" in layer.metadata:
             self.limit_visible_rows = layer.metadata["limit_number_rows"]
         if hasattr(layer, "properties"):
@@ -52,21 +51,11 @@ class TableWidget(QWidget):
 
         action_widget = QWidget()
         action_widget.setLayout(QHBoxLayout())
-        action_widget.layout().addWidget(copy_button, alignment=Qt.AlignTop)
-        action_widget.layout().addWidget(save_button, alignment=Qt.AlignTop)
+        action_widget.layout().addWidget(copy_button)
+        action_widget.layout().addWidget(save_button)
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(action_widget)
-
-        if self.data_not_shown_label:
-            notshown_widget = QWidget()
-            notshown_widget.setLayout(QHBoxLayout())
-            notshown_widget.layout().addWidget(self.data_not_shown_label, alignment=Qt.AlignTop)
-            self.layout().addWidget(notshown_widget)
-            self.layout().setSizeConstraint(QVBoxLayout.SetMinimumSize)
-
-        else:
-
-            self.layout().addWidget(self._view)
+        self.layout().addWidget(self._view)
         action_widget.layout().setSpacing(3)
         action_widget.layout().setContentsMargins(0, 0, 0, 0)
 
@@ -167,6 +156,7 @@ class TableWidget(QWidget):
         """
         Overwrites the content of the table with the content of a given dictionary.
         """
+        print("Set content???")
         if table is None:
             table = {}
 
@@ -218,10 +208,13 @@ class TableWidget(QWidget):
             pass
 
         if max_rows == 0:
-            self.data_not_shown_label = QLabel("Data not shown")
+            self._view.setRowCount(1)
+            for i, column in enumerate(table.keys()):
+                self._view.setHorizontalHeaderItem(i, QTableWidgetItem(column))
+            self._view.setItem(0, 0, QTableWidgetItem(str("Data not shown")))
+            self._view.setSpan(0, 0, 1, len(table.keys())+1)
         else:
             for i, column in enumerate(table.keys()):
-
                 self._view.setHorizontalHeaderItem(i, QTableWidgetItem(column))
                 for j, value in enumerate(table.get(column)):
                     if j>max_rows:
@@ -277,10 +270,12 @@ def add_table(labels_layer: "napari.layers.Layer", viewer: "napari.Viewer", tabi
     """
     dock_widget = get_table(labels_layer, viewer)
     if dock_widget is None:
+        print("HERE")
         dock_widget = TableWidget(labels_layer, viewer)
         # add widget to napari
         viewer.window.add_dock_widget(dock_widget, area='right', name="Properties of " + labels_layer.name, tabify = tabify)
     else:
+        print("HERE2")
         dock_widget.set_content(labels_layer.properties)
         if not dock_widget.parent().isVisible():
             dock_widget.parent().setVisible(True)

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -29,7 +29,10 @@ class TableWidget(QWidget):
 
         self._view = QTableWidget()
         self._view.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        self.limit_visible_rows = 1000
+        self.limit_visible_rows = None
+        if "limit_number_rows" in layer.metadata:
+            if layer.metadata["limit_number_rows"]:
+                self.limit_visible_rows = 1000
         if hasattr(layer, "properties"):
             self.set_content(layer.properties)
         else:

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -29,10 +29,10 @@ class TableWidget(QWidget):
 
         self._view = QTableWidget()
         self._view.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        self.limit_visible_rows = None
+        self.limit_visible_rows = 0
         if "limit_number_rows" in layer.metadata:
             if layer.metadata["limit_number_rows"]:
-                self.limit_visible_rows = 1000
+                self.limit_visible_rows = layer.metadata["limit_number_rows"]
         if hasattr(layer, "properties"):
             self.set_content(layer.properties)
         else:
@@ -197,7 +197,7 @@ class TableWidget(QWidget):
         self._view.clear()
 
         max_rows = len(next(iter(table.values())))
-        if self.limit_visible_rows:
+        if self.limit_visible_rows>0:
             max_rows = np.min([self.limit_visible_rows, max_rows])
 
         try:

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -29,6 +29,7 @@ class TableWidget(QWidget):
 
         self._view = QTableWidget()
         self._view.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.limit_visible_rows = 1000
         if hasattr(layer, "properties"):
             self.set_content(layer.properties)
         else:
@@ -191,8 +192,13 @@ class TableWidget(QWidget):
         self._layer.properties = table
 
         self._view.clear()
+
+        max_rows = len(next(iter(table.values())))
+        if self.limit_visible_rows:
+            max_rows = np.min([self.limit_visible_rows, max_rows])
+
         try:
-            self._view.setRowCount(len(next(iter(table.values()))))
+            self._view.setRowCount(max_rows)
             self._view.setColumnCount(len(table))
         except StopIteration:
             pass
@@ -201,6 +207,8 @@ class TableWidget(QWidget):
 
             self._view.setHorizontalHeaderItem(i, QTableWidgetItem(column))
             for j, value in enumerate(table.get(column)):
+                if j>max_rows:
+                    break
                 self._view.setItem(j, i, QTableWidgetItem(str(value)))
 
     def get_content(self) -> dict:


### PR DESCRIPTION
Hi @haesleinhuepf ,

I'm facing issues with loading huge datasets when working with the napari-clusters-plotter plugin. I try to load a dataset with 32 million entries (2 columns) and it runs out of memory (with 92GB Ram).

My initial thought was to reduce the bit depth of float numbers. Therefore: 

- the first change I made is to preload the csv file, find the columns with float64 type and then load it as float32

However, after making this change I realized that this actually did not consume a lot of memory. The memory is consumed later in the code when you create QTableWidget. I thought in most cases it does not make sense to display 32 million rows. Therefore:

- My second change is to only visualize the first 1k rows (see self.limit_visible_rows in _table.py). That only happens if the checkbox "limit number visible rows" is checked.

With those changes, I can work now work with the napari-clusters-plotter.

Do you think we can include those changes in this plugin?


