### PR TITLE
add Deprecated package as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 napari-tools-menu>=0.1.19
 napari-workflows
 imageio!=2.22.1
+Deprecated


### PR DESCRIPTION
Hi @haesleinhuepf and @zoccoler,

this small PR adds Deprecated package as a dependency, which was causing import errors using the most recent version of the plugin.