### PR TITLE
Make feature maps work for all layers

### DIFF
--- a/napari_skimage_regionprops/_parametric_images.py
+++ b/napari_skimage_regionprops/_parametric_images.py
@@ -3,6 +3,84 @@ from napari_tools_menu import register_function
 import numpy
 from deprecated import deprecated
 
+
+def create_feature_map(layer: "napari.layers.Layer",
+                       selected_column: str,
+                       colormap: str = 'jet'
+                       ) -> "napari.layers.Layer":
+    """
+    Create feature map from layer and column name.
+
+    Parameters
+    ----------
+    layer : "napari.layers.Layer"
+        Layer to create feature map from.
+    column_name : str
+        Column name to create feature map from.
+
+    Returns
+    -------
+    "napari.layers.Layer"
+        Feature map.
+    """
+    # Label layers
+    from napari.layers import Layer, Labels, Points, Vectors, Surface
+    properties = {}
+    if isinstance(layer, Labels):
+        if "label" not in layer.properties.keys():
+            raise ValueError("Layer does not have a 'label' property.")
+        if selected_column is None:
+            return None
+
+        print("Selected column", selected_column)
+
+        data = map_measurements_on_labels(
+            layer, selected_column)
+
+        properties['contrast_limits'] = [np.min(layer.features[selected_column]),
+                                         np.max(layer.features[selected_column])]
+        properties['colormap'] = colormap
+        properties['interpolation'] = 'nearest'
+        layertype = 'image'
+
+    elif isinstance(layer, Points):
+        data = layer.data
+        properties['face_color'] = selected_column
+        properties['face_colormap'] = colormap
+        properties['features'] = {selected_column: layer.features[selected_column].values}
+        layertype = 'points'
+
+    elif isinstance(layer, Vectors):
+        data = layer.data
+        properties['features'] = {selected_column: layer.features[selected_column].values}
+        properties['edge_color'] = selected_column
+        properties['edge_colormap'] = colormap
+        layertype = 'vectors'
+
+    # Surface layer
+    elif isinstance(layer, Surface):
+        data = list(layer.data)
+
+        # We may have stored features in the metadata to avoid napari complaining
+        if not hasattr(layer, "features") and 'features' not in layer.metadata.keys():
+            raise ValueError("Layer does not have a 'features' property.")
+
+        if not hasattr(layer, "features") and "features" in layer.metadata.keys():
+            layer.features = layer.metadata["features"]
+            layer.metadata.pop("features")
+
+        data[2] = np.asarray(layer.features[selected_column].values)
+
+        properties['colormap'] = colormap
+        properties['contrast_limits'] = [np.min(layer.features[selected_column]),
+                                         np.max(layer.features[selected_column])]
+        if "annotation" in selected_column or "CLUSTER_ID" in selected_column:
+            properties.colormap = "hsv"
+        layertype = 'surface'
+
+    return Layer.create(data, properties, layertype)
+
+
 @register_function(menu="Measurement maps > Measurements on labels (nsr)")
 @register_function(menu="Visualization > Measurements on labels (nsr)")
 def map_measurements_on_labels(labels_layer:"napari.layers.Labels", column:str = "label", viewer:"napari.Viewer" = None) -> "napari.types.ImageData":

--- a/napari_skimage_regionprops/_table.py
+++ b/napari_skimage_regionprops/_table.py
@@ -34,6 +34,11 @@ class TableWidget(QWidget):
             content = layer.properties
         elif hasattr(layer, "features"):
             content = layer.features.to_dict('list')
+
+        # to accomodate passing features to surfaces through the metadata
+        elif 'features' in layer.metadata.keys():
+            layer.features = layer.metadata['features']
+            content = layer.features.to_dict('list')
         self.set_content(content)
 
         self._view.clicked.connect(self._clicked_table)
@@ -78,7 +83,7 @@ class TableWidget(QWidget):
         """
         from ._parametric_images import create_feature_map
         selected_column = list(self._table.keys())[self._view.currentColumn()]
-        print('Selected ', selected_column)
+        print('Selected', selected_column)
         layer = create_feature_map(self._layer, selected_column)
         layer.name = selected_column + " in " + self._layer.name
         self._viewer.add_layer(layer)

--- a/napari_skimage_regionprops/_tests/test_featuremaps.py
+++ b/napari_skimage_regionprops/_tests/test_featuremaps.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+
+def test_label_featuremaps(make_napari_viewer):
+    from napari_skimage_regionprops import regionprops
+    from .._table import create_feature_map
+
+    viewer = make_napari_viewer()
+    
+    image = np.asarray([
+        [0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 0, 0, 2, 2],
+        [1, 1, 1, 0, 0, 2, 2],
+        [1, 1, 1, 0, 0, 2, 2],
+        [0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 3, 3, 3, 0, 0],
+        [0, 0, 3, 3, 3, 0, 4],
+    ]).astype(float)
+
+    image_layer = viewer.add_image(image)
+    labels_layer = viewer.add_labels(image.astype(int))
+
+    # analyze a few things
+    regionprops(image_layer, labels_layer, True, False, False, False, False, False, viewer)
+    feature_map = create_feature_map(viewer.layers[-1], 'area')
+
+    assert feature_map.data.max() == 9
+
+
+def test_vector_featuremaps(make_napari_viewer):
+    from napari_skimage_regionprops import regionprops
+    from .._table import create_feature_map
+    import pandas as pd
+
+    viewer = make_napari_viewer()
+
+    np.random.seed(0)
+    vectors = np.random.random((10, 2, 3))
+    feature1 = np.random.random((10))
+    feature2 = np.random.random((10))
+    features = pd.DataFrame({'feature1': feature1, 'feature2': feature2})
+    layer = viewer.add_vectors(vectors, features=features)
+
+    feature_map = create_feature_map(layer, 'feature1')
+    viewer.add_layer(feature_map)
+
+
+def test_points_featuremaps(make_napari_viewer):
+    from napari_skimage_regionprops import regionprops
+    from .._table import create_feature_map
+    import pandas as pd
+
+    viewer = make_napari_viewer()
+
+    np.random.seed(0)
+    points = np.random.random((10, 2))
+    feature1 = np.random.random((10))
+    feature2 = np.random.random((10))
+    features = pd.DataFrame({'feature1': feature1, 'feature2': feature2})
+    layer = viewer.add_points(points, features=features)
+
+    feature_map = create_feature_map(layer, 'feature1')
+    viewer.add_layer(feature_map)
+
+
+def test_surface_featuremaps(make_napari_viewer):
+    from napari_skimage_regionprops import regionprops
+    from .._table import create_feature_map
+    import pandas as pd
+
+    viewer = make_napari_viewer()
+
+    np.random.seed(0)
+    vertices = np.random.random((10, 3))
+    faces = np.random.randint(size=(10, 3), high=9, low=0)
+    surface = (vertices, faces)
+    feature1 = np.random.random((10))
+    feature2 = np.random.random((10))
+    features = pd.DataFrame({'feature1': feature1, 'feature2': feature2})
+    layer = viewer.add_surface(surface, metadata={'features': features})
+
+    feature_map = create_feature_map(layer, 'feature1')
+    assert np.array_equal(feature_map.data[2], feature1)


### PR DESCRIPTION
Hi @haesleinhuepf,

I made a little addon to the results table. I created a function `create_featuremaps` that generalizes the functionality that was previously in the `_on_double_click()` function of the `TableWidget`, which is triggered when the table header is doubleclicked and which generated a featuremap.

The `_on_double_click()` function now just calls the new `create_featuremaps` function and passes the layer and the feature column to it. The new function then visualizes the feature accordingly for every layer:
- As intensity image for `Labels` layer
- As points layer with `face_color` according to feature
- As vectors layer with `edge_color` according to feature
- As surface layer with `surface[2]` overwritten with the values of the selected feature.

Since `viewer.add_surface(data, features=features)` is not allowed whereas `viewer.add_surface(data, metadata = {'features':features})` is, I added a little snipped in the `__init__` of the `TableWidget`, which moves the features from the metadata to `layer.features`.

## QA

- [x] Added tests to cover function for all intended layers
- [x] Checked whether everything works from the viewer

Let me know what you think! 