### PR TITLE
Clip min eigenvalues to 0 to block negative values in sqrt

### DIFF
--- a/napari_skimage_regionprops/_regionprops.py
+++ b/napari_skimage_regionprops/_regionprops.py
@@ -193,7 +193,7 @@ def ellipsoid_axis_lengths(table):
     S = np.asarray([[sxx, sxy, sxz], [sxy, syy, syz], [sxz, syz, szz]])
     # determine eigenvalues in descending order
     eigvals = np.sort(np.linalg.eigvalsh(S))[::-1]
-    return tuple([math.sqrt(20.0 * e) for e in eigvals])
+    return tuple([math.sqrt(20.0 * np.clip(e, a_min=0, a_max=None)) for e in eigvals])
 
 regionprops_table_all_frames = analyze_all_frames(regionprops_table)
 register_function(regionprops_table_all_frames, menu="Measurement tables > Regionprops of all frames (nsr)")

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-xvfb ; sys_platform == 'linux'
     # you can remove these if you don't use them
-    napari
+    napari<0.5.0
     magicgui
     pytest-qt
     qtpy


### PR DESCRIPTION
This sometimes can happen with floating point representation of very small numbers.

This solves #88 .

